### PR TITLE
[codex] Add account id CLI option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-MF_IMPORT_CSV_ACCOUNT_URL="<インポート先の口座URL>"
+MF_IMPORT_CSV_ACCOUNT_URL="<インポート先の口座URL。--account-id指定時は省略可>"
 MF_IMPORT_CSV_USER="<自分のアカウント>"
 MF_IMPORT_CSV_PASSWORD="<自分のパスワード>"
 MF_IMPORT_CSV_BROWSER_ENGINE="selenium"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - dry-runによる登録予定内容の確認
 - validate-onlyによるCSV検証のみの実行
 - Selenium / Playwright のブラウザエンジン切替
+- CLI引数による手入力口座ID指定
 
 ## 必要な環境
 
@@ -53,7 +54,7 @@ python -m playwright install chromium
    cp .env.example .env
    ```
 2. `.env` に、マネーフォワードのユーザー名、パスワード、インポート先の口座URLを指定してください。
-   - `MF_IMPORT_CSV_ACCOUNT_URL`: インポート先の口座URL
+   - `MF_IMPORT_CSV_ACCOUNT_URL`: インポート先の口座URL。`--account-id` 指定時は省略できます。
    - `MF_IMPORT_CSV_USER`: MoneyForwardログインユーザー
    - `MF_IMPORT_CSV_PASSWORD`: MoneyForwardログインパスワード
    - `MF_IMPORT_CSV_BROWSER_ENGINE`: `selenium` または `playwright`（未指定時は `selenium`）
@@ -72,6 +73,7 @@ python -m playwright install chromium
    MF_IMPORT_CSV_REUSE_LOGIN_SESSION="true"
    MF_IMPORT_CSV_BROWSER_PROFILE_DIR=".auth/moneyforward-playwright"
    ```
+   - 手入力口座IDをCLIで指定する場合は、`.env` の `MF_IMPORT_CSV_ACCOUNT_URL` より `--account-id` が優先されます。
    - `.env` はGit管理対象にしないでください。
    - `.auth/` はログイン済みブラウザ状態を含むため、Git管理対象にしないでください。
    - 認証情報やURLの実値は、コード、README、レポート、Git管理対象ファイルに含めないでください。
@@ -99,6 +101,13 @@ python mf_import_csv.py data.csv
 
 - `data.csv` はインポートするCSVファイルのパスです。
 - 通常実行ではCSV検証後にマネーフォワードへログインし、登録処理を行います。
+- インポート先口座を手入力口座IDで指定する場合は、以下のように実行します。
+
+```sh
+python mf_import_csv.py data.csv --account-id 123456
+```
+
+`--account-id` は `https://moneyforward.com/accounts/show_manual/123456` のような口座URLに変換され、`.env` の `MF_IMPORT_CSV_ACCOUNT_URL` より優先されます。
 
 ## ブラウザエンジン設定
 

--- a/config.py
+++ b/config.py
@@ -19,15 +19,17 @@ def _parse_bool(value, default=False):
     sys.exit(1)
 
 
-def load_required_env():
+def load_required_env(require_account_url=True):
     from dotenv import load_dotenv
 
     load_dotenv()
     required_env_vars = {
-        "MF_IMPORT_CSV_ACCOUNT_URL": os.getenv("MF_IMPORT_CSV_ACCOUNT_URL"),
         "MF_IMPORT_CSV_USER": os.getenv("MF_IMPORT_CSV_USER"),
         "MF_IMPORT_CSV_PASSWORD": os.getenv("MF_IMPORT_CSV_PASSWORD"),
     }
+    account_url = os.getenv("MF_IMPORT_CSV_ACCOUNT_URL")
+    if require_account_url:
+        required_env_vars["MF_IMPORT_CSV_ACCOUNT_URL"] = account_url
 
     missing_env_vars = [name for name, value in required_env_vars.items() if not value]
     if missing_env_vars:
@@ -39,6 +41,7 @@ def load_required_env():
 
     required_env_vars.update(
         {
+            "MF_IMPORT_CSV_ACCOUNT_URL": account_url,
             "MF_IMPORT_CSV_BROWSER_ENGINE": os.getenv(
                 "MF_IMPORT_CSV_BROWSER_ENGINE", "selenium"
             ).strip()

--- a/mf_import_csv.py
+++ b/mf_import_csv.py
@@ -6,11 +6,26 @@ from csv_validation import print_dry_run, print_validation_result, validate_csv
 from browser_engine import run_import
 
 
+def build_account_url(account_id):
+    account_id = account_id.strip()
+    if not account_id:
+        raise ValueError("--account-id must not be empty.")
+
+    return "https://moneyforward.com/accounts/show_manual/" + account_id
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
         description="MoneyForwardへCSVデータを登録します。"
     )
     parser.add_argument("input_file", help="読み込むCSVファイル")
+    parser.add_argument(
+        "--account-id",
+        help=(
+            "手入力口座IDを指定します。指定時は"
+            "MF_IMPORT_CSV_ACCOUNT_URLより優先されます。"
+        ),
+    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -46,7 +61,14 @@ def main():
     if args.dry_run:
         return 0
 
-    env = load_required_env()
+    env = load_required_env(require_account_url=args.account_id is None)
+    if args.account_id is not None:
+        try:
+            env["MF_IMPORT_CSV_ACCOUNT_URL"] = build_account_url(args.account_id)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
     run_import(args.input_file, result.entries, env)
     return 0
 


### PR DESCRIPTION
@nanosns

## Summary
- Add `--account-id` to build a manual account URL from a CLI-supplied ID.
- Keep the existing `.env` account URL path when `--account-id` is omitted.
- Document the option in `README.md` and `.env.example`.

## Checks
- `git diff --check`
- `python3 -m compileall .`
- `python3 mf_import_csv.py --help`
- `python3 mf_import_csv.py /tmp/mf_import_csv_issue20_sample.csv --validate-only --account-id 123456`

No MoneyForward browser operation, real data update, or real CSV import was performed.